### PR TITLE
Clean up jexl-rs and expose failing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,9 @@ name = "jexl-eval"
 version = "0.1.0"
 dependencies = [
  "jexl-parser 0.1.0",
+ "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -347,11 +349,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -473,6 +491,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +508,24 @@ dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -587,7 +633,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_shared 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cccdc7557a98fe98453030f077df7f3a042052fae465bb61d2c2c41435cfd9b6"
+"checksum proc-macro2 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 "checksum quote 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b71f9f575d55555aa9c06188be9d4e2bfc83ed02537948ac0d520c24d0419f1a"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum redox_syscall 0.1.57 (registry+https://github.com/rust-lang/crates.io-index)" = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 "checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 "checksum regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
@@ -602,7 +650,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum string_cache 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
 "checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum syn 0.14.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4bad7abdf6633f07c7046b90484f1d9dc055eca39f8c991177b1046ce61dba9a"
+"checksum syn 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "e69abc24912995b3038597a7a593be5053eb0fb44f3cc5beec0deb421790c1f4"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+"checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+"checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/jexl-eval/Cargo.toml
+++ b/jexl-eval/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Mike Cooper <mythmon@gmail.com>"]
 [dependencies]
 jexl-parser = {path = "../jexl-parser"}
 serde_json = "1"
+serde = "1"
+thiserror = "1"

--- a/jexl-eval/src/error.rs
+++ b/jexl-eval/src/error.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use jexl_parser::{ast::OpCode, ParseError, Token};
+
+use serde_json::Value;
+
+pub type Result<'a, T, E = EvaluationError<'a>> = std::result::Result<T, E>;
+#[derive(Debug, thiserror::Error)]
+pub enum EvaluationError<'a> {
+    #[error("Parsing error: {0}")]
+    ParseError(Box<ParseError<usize, Token<'a>, &'a str>>),
+    #[error("Invalid binary operation, left: {left}, right: {right}, operation: {operation}")]
+    InvalidBinaryOp {
+        left: Value,
+        right: Value,
+        operation: OpCode,
+    },
+    #[error("Unknown transform: {0}")]
+    UnknownTransform(String),
+    #[error("Duplicate object key: {0}")]
+    DuplicateObjectKey(String),
+    #[error("Invalid context provided")]
+    InvalidContext,
+    #[error("Invalid index type")]
+    InvalidIndexType,
+    #[error("Invalid json: {0}")]
+    JSONError(#[from] serde_json::Error),
+}
+
+impl<'a> From<ParseError<usize, Token<'a>, &'a str>> for EvaluationError<'a> {
+    fn from(cause: ParseError<usize, Token<'a>, &'a str>) -> Self {
+        EvaluationError::ParseError(Box::new(cause))
+    }
+}

--- a/jexl-eval/src/lib.rs
+++ b/jexl-eval/src/lib.rs
@@ -1,30 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A JEXL evaluator written in Rust
+//! This crate depends on a JEXL parser crate that handles all the parsing
+//! and is a part of the same workspace.
+//! JEXL is an expression language used by Mozilla, you can find more information here: https://github.com/mozilla/mozjexl
+//!
+//! # How to use
+//! The access point for this crate is the `eval` functions
+//! You can use the `eval` function directly to evaluate standalone statements
+//!
+//! For example:
+//! ```rust
+//! use jexl_eval::eval;
+//! assert_eq!(eval("'Hello ' + 'World'").unwrap(), "Hello World");
+//! ```
+//!
+//! You can also run the statements against a context using the `eval_in_context` function
+//! The context can be any type that implements the `serde::Serializable` trait
+//! and the function will return errors if the statement doesn't match the context
+//!
+//! For example:
+//! ```rust
+//! use jexl_eval::eval_in_context;
+//! use serde_json::json as value;
+//! let context = value!({"a": {"b": 2.0}});
+//! assert_eq!(eval_in_context("a.b", context).unwrap(), value!(2.0));
+//! ```
+//!
+
 use jexl_parser::{
     ast::{Expression, OpCode},
-    ParseError, Parser, Token,
+    Parser,
 };
 use serde_json::{json as value, Value};
 
+pub mod error;
+use error::*;
+
 const EPSILON: f64 = 0.000001f64;
-
-#[derive(Debug, PartialEq)]
-pub enum EvaluationError<'a> {
-    ParseError(Box<ParseError<usize, Token<'a>, &'a str>>),
-    InvalidBinaryOp {
-        left: Value,
-        right: Value,
-        operation: OpCode,
-    },
-    UnknownTransform(String),
-    DuplicateObjectKey(String),
-    InvalidContext,
-    InvalidIndexType,
-}
-
-impl<'a> From<ParseError<usize, Token<'a>, &'a str>> for EvaluationError<'a> {
-    fn from(cause: ParseError<usize, Token<'a>, &'a str>) -> Self {
-        EvaluationError::ParseError(Box::new(cause))
-    }
-}
 
 trait Truthy {
     fn is_truthy(&self) -> bool;
@@ -40,7 +55,7 @@ impl Truthy for Value {
             Value::Bool(b) => *b,
             Value::Null => true,
             Value::Number(f) => f.as_f64().unwrap() != 0.0,
-            Value::String(s) => s.len() > 0,
+            Value::String(s) => !s.is_empty(),
             // It would be better if these depended on the contents of the
             // object (empty array/object is falsey, non-empty is truthy, like
             // in Python) but this matches JS semantics. Is it worth changing?
@@ -52,119 +67,103 @@ impl Truthy for Value {
 
 type Context = Value;
 
-pub struct Evaluator {}
+pub fn eval(input: &str) -> Result<'_, Value> {
+    let context = value!({});
+    eval_in_context(input, &context)
+}
 
-impl Evaluator {
-    pub fn new() -> Self {
-        Self {}
+pub fn eval_in_context<T: serde::Serialize>(input: &str, context: T) -> Result<'_, Value> {
+    let tree = Parser::parse(input)?;
+    let context = serde_json::to_value(context)?;
+    if !context.is_object() {
+        return Err(EvaluationError::InvalidContext);
     }
+    eval_ast(tree, &context)
+}
 
-    pub fn eval<'a>(&self, input: &'a str) -> Result<Value, EvaluationError<'a>> {
-        let context = value!({});
-        self.eval_in_context(input, &context)
-    }
+fn eval_ast<'a>(ast: Expression, context: &Context) -> Result<'a, Value> {
+    match ast {
+        Expression::Number(n) => Ok(value!(n)),
+        Expression::Boolean(b) => Ok(value!(b)),
+        Expression::String(s) => Ok(value!(s)),
+        Expression::Array(xs) => xs.into_iter().map(|x| eval_ast(*x, context)).collect(),
 
-    pub fn eval_in_context<'a, 'b>(
-        &self,
-        input: &'a str,
-        context: impl Into<&'b Context>,
-    ) -> Result<Value, EvaluationError<'a>> {
-        let tree = Parser::parse(input)?;
-        let context = context.into();
-        if !context.is_object() {
-            return Err(EvaluationError::InvalidContext);
+        Expression::Object(items) => {
+            let mut map = serde_json::Map::with_capacity(items.len());
+            for (key, expr) in items.into_iter() {
+                if map.contains_key(&key) {
+                    return Err(EvaluationError::DuplicateObjectKey(key));
+                }
+                let value = eval_ast(*expr, context)?;
+                map.insert(key, value);
+            }
+            Ok(Value::Object(map))
         }
-        self.eval_ast(tree, context)
-    }
 
-    fn eval_ast<'a>(
-        &self,
-        ast: Expression,
-        context: &Context,
-    ) -> Result<Value, EvaluationError<'a>> {
-        match ast {
-            Expression::Number(n) => Ok(value!(n)),
-            Expression::Boolean(b) => Ok(value!(b)),
-            Expression::String(s) => Ok(value!(s)),
-            Expression::Array(xs) => xs.into_iter().map(|x| self.eval_ast(*x, context)).collect(),
-
-            Expression::Object(items) => {
-                let mut map = serde_json::Map::with_capacity(items.len());
-                for (key, expr) in items.into_iter() {
-                    if map.contains_key(&key) {
-                        return Err(EvaluationError::DuplicateObjectKey(key));
-                    }
-                    let value = self.eval_ast(*expr, context)?;
-                    map.insert(key, value);
+        Expression::IdentifierSequence(exprs) => {
+            assert!(!exprs.is_empty());
+            let mut rv: Option<&Value> = Some(context);
+            for expr in exprs.into_iter() {
+                let key = eval_ast(*expr, context)?;
+                if let Some(value) = rv {
+                    rv = match key {
+                        Value::String(s) => value.get(&s),
+                        Value::Number(f) => value.get(f.as_f64().unwrap().floor() as usize),
+                        _ => return Err(EvaluationError::InvalidIndexType),
+                    };
+                } else {
+                    break;
                 }
-                Ok(Value::Object(map))
             }
 
-            Expression::IdentifierSequence(exprs) => {
-                assert!(!exprs.is_empty());
-                let mut rv: Option<&Value> = Some(context);
-                for expr in exprs.into_iter() {
-                    let key = self.eval_ast(*expr, context)?;
-                    if let Some(value) = rv {
-                        rv = match key {
-                            Value::String(s) => value.get(&s),
-                            Value::Number(f) => value.get(f.as_f64().unwrap().floor() as usize),
-                            _ => return Err(EvaluationError::InvalidIndexType),
-                        };
-                    } else {
-                        break;
-                    }
+            Ok(rv.unwrap_or(&value!(null)).clone())
+        }
+
+        Expression::BinaryOperation {
+            left,
+            right,
+            operation,
+        } => {
+            let left = eval_ast(*left, context)?;
+            let right = eval_ast(*right, context)?;
+            match (operation, left, right) {
+                (OpCode::And, a, b) => Ok(if a.is_truthy() { b } else { a }),
+                (OpCode::Or, a, b) => Ok(if a.is_truthy() { a } else { b }),
+
+                (op, Value::Number(a), Value::Number(b)) => {
+                    let left = a.as_f64().unwrap();
+                    let right = b.as_f64().unwrap();
+                    Ok(match op {
+                        OpCode::Add => value!(left + right),
+                        OpCode::Subtract => value!(left - right),
+                        OpCode::Multiply => value!(left * right),
+                        OpCode::Divide => value!(left / right),
+                        OpCode::FloorDivide => value!((left / right).floor()),
+                        OpCode::Modulus => value!(left % right),
+                        OpCode::Exponent => value!(left.powf(right)),
+                        OpCode::Less => value!(left < right),
+                        OpCode::Greater => value!(left > right),
+                        OpCode::LessEqual => value!(left <= right),
+                        OpCode::GreaterEqual => value!(left >= right),
+                        OpCode::Equal => value!((left - right).abs() < EPSILON),
+                        OpCode::NotEqual => value!((left - right).abs() > EPSILON),
+                        OpCode::In => value!(false),
+                        OpCode::And | OpCode::Or => {
+                            unreachable!("Covered by previous case in parent match")
+                        }
+                    })
                 }
 
-                Ok(rv.unwrap_or(&value!(null)).clone())
-            }
-
-            Expression::BinaryOperation {
-                left,
-                right,
-                operation,
-            } => {
-                let left = self.eval_ast(*left, context)?;
-                let right = self.eval_ast(*right, context)?;
-                match (operation, left, right) {
-                    (OpCode::And, a, b) => Ok(if a.is_truthy() { b } else { a }),
-                    (OpCode::Or, a, b) => Ok(if a.is_truthy() { a } else { b }),
-
-                    (op, Value::Number(a), Value::Number(b)) => {
-                        let left = a.as_f64().unwrap();
-                        let right = b.as_f64().unwrap();
-                        Ok(match op {
-                            OpCode::Add => value!(left + right),
-                            OpCode::Subtract => value!(left - right),
-                            OpCode::Multiply => value!(left * right),
-                            OpCode::Divide => value!(left / right),
-                            OpCode::FloorDivide => value!((left / right).floor()),
-                            OpCode::Modulus => value!(left % right),
-                            OpCode::Exponent => value!(left.powf(right)),
-                            OpCode::Less => value!(left < right),
-                            OpCode::Greater => value!(left > right),
-                            OpCode::LessEqual => value!(left <= right),
-                            OpCode::GreaterEqual => value!(left >= right),
-                            OpCode::Equal => value!((left - right).abs() < EPSILON),
-                            OpCode::NotEqual => value!((left - right).abs() > EPSILON),
-                            OpCode::In => value!(false),
-                            OpCode::And | OpCode::Or => {
-                                unreachable!("Covered by previous case in parent match")
-                            }
-                        })
-                    }
-
-                    (OpCode::Add, Value::String(a), Value::String(b)) => {
-                        Ok(value!(format!("{}{}", a, b)))
-                    }
-                    (OpCode::In, Value::String(a), Value::String(b)) => Ok(value!(b.contains(&a))),
-
-                    (operation, left, right) => Err(EvaluationError::InvalidBinaryOp {
-                        operation,
-                        left,
-                        right,
-                    }),
+                (OpCode::Add, Value::String(a), Value::String(b)) => {
+                    Ok(value!(format!("{}{}", a, b)))
                 }
+                (OpCode::In, Value::String(a), Value::String(b)) => Ok(value!(b.contains(&a))),
+                (OpCode::Equal, Value::String(a), Value::String(b)) => Ok(value!(a == b)),
+                (operation, left, right) => Err(EvaluationError::InvalidBinaryOp {
+                    operation,
+                    left,
+                    right,
+                }),
             }
         }
     }
@@ -177,80 +176,66 @@ mod tests {
 
     #[test]
     fn test_literal() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("1"), Ok(value!(1.0)));
+        assert_eq!(eval("1").unwrap(), value!(1.0));
     }
 
     #[test]
     fn test_binary_expression_addition() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("1 + 2"), Ok(value!(3.0)));
+        assert_eq!(eval("1 + 2").unwrap(), value!(3.0));
     }
 
     #[test]
     fn test_binary_expression_multiplication() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("2 * 3"), Ok(value!(6.0)));
+        assert_eq!(eval("2 * 3").unwrap(), value!(6.0));
     }
 
     #[test]
     fn test_precedence() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("2 + 3 * 4"), Ok(value!(14.0)));
+        assert_eq!(eval("2 + 3 * 4").unwrap(), value!(14.0));
     }
 
     #[test]
     fn test_parenthesis() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("(2 + 3) * 4"), Ok(value!(20.0)));
+        assert_eq!(eval("(2 + 3) * 4").unwrap(), value!(20.0));
     }
 
     #[test]
     fn test_string_concat() {
-        let evaluator = Evaluator::new();
-        assert_eq!(
-            evaluator.eval("'Hello ' + 'World'"),
-            Ok(value!("Hello World"))
-        );
+        assert_eq!(eval("'Hello ' + 'World'").unwrap(), value!("Hello World"));
     }
 
     #[test]
     fn test_true_comparison() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("2 > 1"), Ok(value!(true)));
+        assert_eq!(eval("2 > 1").unwrap(), value!(true));
     }
 
     #[test]
     fn test_false_comparison() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("2 <= 1"), Ok(value!(false)));
+        assert_eq!(eval("2 <= 1").unwrap(), value!(false));
     }
 
     #[test]
     fn test_boolean_logic() {
-        let evaluator = Evaluator::new();
         assert_eq!(
-            evaluator.eval("'foo' && 6 >= 6 && 0 + 1 && true"),
-            Ok(value!(true))
+            eval("'foo' && 6 >= 6 && 0 + 1 && true").unwrap(),
+            value!(true)
         );
     }
 
     #[test]
     fn test_identifier() {
         let context = value!({"a": 1.0});
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval_in_context("a", &context), Ok(value!(1.0)));
+        assert_eq!(eval_in_context("a", context).unwrap(), value!(1.0));
     }
 
     #[test]
     fn test_identifier_chain() {
         let context = value!({"a": {"b": 2.0}});
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval_in_context("a.b", &context), Ok(value!(2.0)));
+        assert_eq!(eval_in_context("a.b", context).unwrap(), value!(2.0));
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_context_filter_arrays() {
         let context = value!({
             "foo": {
@@ -261,10 +246,9 @@ mod tests {
                 ]
             }
         });
-        let evaluator = Evaluator::new();
         assert_eq!(
-            evaluator.eval_in_context("foo.bar[.tek == 'baz']", &context),
-            Ok(value!([{"tek": "baz"}]))
+            eval_in_context("foo.bar[.tek == 'baz']", &context).unwrap(),
+            value!([{"tek": "baz"}])
         );
     }
 
@@ -279,62 +263,57 @@ mod tests {
                 ]
             }
         });
-        let evaluator = Evaluator::new();
         assert_eq!(
-            evaluator.eval_in_context("foo.bar[1].tek", &context),
-            Ok(value!("baz"))
+            eval_in_context("foo.bar[1].tek", context).unwrap(),
+            value!("baz")
         );
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_object_expression_properties() {
         let context = value!({"foo": {"baz": {"bar": "tek"}}});
-        let evaluator = Evaluator::new();
         assert_eq!(
-            evaluator.eval_in_context("foo['ba' + 'z']", &context),
-            Ok(value!("tek"))
+            eval_in_context("foo['ba' + 'z']", &context).unwrap(),
+            value!("tek")
         );
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_missing_transform_exception() {
-        let evaluator = Evaluator::new();
-        assert_eq!(
-            evaluator.eval("'hello'|world"),
-            Err(EvaluationError::UnknownTransform("world".to_string()))
-        );
+        let err = eval("'hello'|world").unwrap_err();
+        if let EvaluationError::UnknownTransform(transform) = err {
+            assert_eq!(transform, "world")
+        } else {
+            panic!("Should have thrown an unknown transform error")
+        }
     }
 
     #[test]
     fn test_divfloor() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("7 // 2"), Ok(value!(3.0)));
+        assert_eq!(eval("7 // 2").unwrap(), value!(3.0));
     }
 
     #[test]
     fn test_empty_object_literal() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("{}"), Ok(value!({})));
+        assert_eq!(eval("{}").unwrap(), value!({}));
     }
 
     #[test]
     fn test_object_literal_strings() {
-        let evaluator = Evaluator::new();
         assert_eq!(
-            evaluator.eval("{'foo': {'bar': 'tek'}}"),
-            Ok(value!({"foo": {"bar": "tek"}}))
+            eval("{'foo': {'bar': 'tek'}}").unwrap(),
+            value!({"foo": {"bar": "tek"}})
         );
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_object_literal_identifiers() {
-        let evaluator = Evaluator::new();
         assert_eq!(
-            evaluator.eval("{foo: {bar: 'tek'}}"),
-            Ok(value!({"foo": {"bar": "tek"}}))
+            eval("{foo: {bar: 'tek'}}").unwrap(),
+            value!({"foo": {"bar": "tek"}})
         );
     }
 
@@ -348,7 +327,7 @@ mod tests {
             default_unary_operators
         )
         evaluator = Evaluator(config)
-        result = evaluator.evaluate(tree('foo|half + 3'), {'foo': 10})
+        result = evaluate(tree('foo|half + 3'), {'foo': 10})
         assert result == 8
 
     def test_transforms_multiple_arguments():
@@ -360,83 +339,73 @@ mod tests {
             }
         )
         evaluator = Evaluator(config)
-        result = evaluator.evaluate(tree('"foo"|concat("baz", "bar", "tek")'))
+        result = evaluate(tree('"foo"|concat("baz", "bar", "tek")'))
         assert result == 'foo: bazbartek'
 
     */
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_object_literal_properties() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("{foo: 'bar'}.foo"), Ok(value!("bar")));
+        assert_eq!(eval("{foo: 'bar'}.foo").unwrap(), value!("bar"));
     }
 
     #[test]
     fn test_array_literal() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("['foo', 1+2]"), Ok(value!(["foo", 3.0])));
+        assert_eq!(eval("['foo', 1+2]").unwrap(), value!(["foo", 3.0]));
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_array_literal_indexing() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("[1, 2, 3][1]"), Ok(value!(2.0)));
+        assert_eq!(eval("[1, 2, 3][1]").unwrap(), value!(2.0));
     }
 
     #[test]
     fn test_in_operator_string() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("'bar' in 'foobartek'"), Ok(value!(true)));
-        assert_eq!(evaluator.eval("'baz' in 'foobartek'"), Ok(value!(false)));
+        assert_eq!(eval("'bar' in 'foobartek'").unwrap(), value!(true));
+        assert_eq!(eval("'baz' in 'foobartek'").unwrap(), value!(false));
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_in_operator_array() {
-        let evaluator = Evaluator::new();
         assert_eq!(
-            evaluator.eval("'bar' in ['foo', 'bar', 'tek']"),
-            Ok(value!(true))
+            eval("'bar' in ['foo', 'bar', 'tek']").unwrap(),
+            value!(true)
         );
         assert_eq!(
-            evaluator.eval("'baz' in ['foo', 'bar', 'tek']"),
-            Ok(value!(false))
+            eval("'baz' in ['foo', 'bar', 'tek']").unwrap(),
+            value!(false)
         );
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic]
     fn test_conditional_expression() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("'foo' ? 1 : 2"), Ok(value!(1)));
-        assert_eq!(evaluator.eval("'' ? 1 : 2"), Ok(value!(2)));
+        assert_eq!(eval("'foo' ? 1 : 2").unwrap(), value!(1));
+        assert_eq!(eval("'' ? 1 : 2").unwrap(), value!(2));
     }
 
     #[test]
     fn test_arbitrary_whitespace() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("(\t2\n+\n3) *\n4\n\r\n"), Ok(value!(20.0)));
+        assert_eq!(eval("(\t2\n+\n3) *\n4\n\r\n").unwrap(), value!(20.0));
     }
 
     #[test]
     fn test_non_integer() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("1.5 * 3.0"), Ok(value!(4.5)))
+        assert_eq!(eval("1.5 * 3.0").unwrap(), value!(4.5));
     }
 
     #[test]
     fn test_string_literal() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("'hello world'"), Ok(value!("hello world")));
-        assert_eq!(evaluator.eval("\"hello world\""), Ok(value!("hello world")));
+        assert_eq!(eval("'hello world'").unwrap(), value!("hello world"));
+        assert_eq!(eval("\"hello world\"").unwrap(), value!("hello world"));
     }
 
     #[test]
     fn test_string_escapes() {
-        let evaluator = Evaluator::new();
-        assert_eq!(evaluator.eval("'a\\'b'"), Ok(value!("a'b")));
-        assert_eq!(evaluator.eval("\"a\\\"b\""), Ok(value!("a\"b")));
+        assert_eq!(eval("'a\\'b'").unwrap(), value!("a'b"));
+        assert_eq!(eval("\"a\\\"b\"").unwrap(), value!("a\"b"));
     }
 }

--- a/jexl-parser/build.rs
+++ b/jexl-parser/build.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 fn main() {
     lalrpop::process_root().unwrap();
 }

--- a/jexl-parser/src/ast.rs
+++ b/jexl-parser/src/ast.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 #[derive(Debug, PartialEq)]
 pub enum Expression {
     Number(f64),
@@ -31,4 +35,31 @@ pub enum OpCode {
     Modulus,
     Exponent,
     In,
+}
+
+impl std::fmt::Display for OpCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                OpCode::Add => "Add",
+                OpCode::Subtract => "Subtract",
+                OpCode::Multiply => "Multiply",
+                OpCode::Divide => "Divide",
+                OpCode::FloorDivide => "Floor division",
+                OpCode::Less => "Less than",
+                OpCode::LessEqual => "Less than or equal to",
+                OpCode::Greater => "Greater than",
+                OpCode::GreaterEqual => "Greater than or equal to",
+                OpCode::Equal => "Equal",
+                OpCode::NotEqual => "Not equal",
+                OpCode::And => "Bitwise And",
+                OpCode::Or => "Bitwise Or",
+                OpCode::Modulus => "Modulus",
+                OpCode::Exponent => "Exponent",
+                OpCode::In => "In",
+            }
+        )
+    }
 }

--- a/jexl-parser/src/lib.rs
+++ b/jexl-parser/src/lib.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 pub mod ast;
 mod parser {
     include!(concat!(env!("OUT_DIR"), "/parser.rs"));


### PR DESCRIPTION
Minor cleanups in the evaluator, and exposed some failing tests

We had a few tests marked with `should_panic`, removed those for now. Although it might be a good idea to keep the `should_panic` and iterate on fixing them.

Cleanups:
 - Removed the struct `Evaluator` and instead the consumers can call `eval` directly
 - Separated the error details into a separate module, and used `thiserror` to define errors