### PR TITLE
Adds transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "jexl-eval"
 version = "0.1.2-alpha.0"
 dependencies = [
- "jexl-parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jexl-parser 0.1.1",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -244,16 +244,6 @@ dependencies = [
 [[package]]
 name = "jexl-parser"
 version = "0.1.1"
-dependencies = [
- "lalrpop 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lalrpop-util 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "jexl-parser"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lalrpop 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lalrpop-util 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -631,7 +621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum indexmap 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
 "checksum itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
-"checksum jexl-parser 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "18425d84229ff68498da1621b37fe2ae6dd69c444120a1c6caee44382e0763f8"
 "checksum lalrpop 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6f55673d283313791404be21209bb433f128f7e5c451986df107eb5fdbd68d2"
 "checksum lalrpop-util 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7e88f15a7d31dfa8fb607986819039127f0161058a3b248a146142d276cbd28"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "jexl-eval"
 version = "0.1.2-alpha.0"
 dependencies = [
+ "anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "jexl-parser 0.1.1",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -590,6 +596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)" = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
+"checksum anyhow 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 "checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum ascii-canvas 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29"

--- a/jexl-eval/Cargo.toml
+++ b/jexl-eval/Cargo.toml
@@ -8,7 +8,8 @@ license = "MPL-2.0"
 repository = "https://github.com/mozilla/jexl-rs"
 
 [dependencies]
-jexl-parser = {path = "../jexl-parser"}
+jexl-parser = { version = "0.1.0", path = "../jexl-parser" }
 serde_json = "1"
 serde = "1"
 thiserror = "1"
+anyhow = "1"

--- a/jexl-eval/Cargo.toml
+++ b/jexl-eval/Cargo.toml
@@ -8,8 +8,7 @@ license = "MPL-2.0"
 repository = "https://github.com/mozilla/jexl-rs"
 
 [dependencies]
-# jexl-parser = {path = "../jexl-parser"}
-jexl-parser = "0.1.1"
+jexl-parser = {path = "../jexl-parser"}
 serde_json = "1"
 serde = "1"
 thiserror = "1"

--- a/jexl-eval/src/error.rs
+++ b/jexl-eval/src/error.rs
@@ -27,6 +27,8 @@ pub enum EvaluationError<'a> {
     InvalidIndexType,
     #[error("Invalid json: {0}")]
     JSONError(#[from] serde_json::Error),
+    #[error("Custom error: {0}")]
+    CustomError(#[from] anyhow::Error),
 }
 
 impl<'a> From<ParseError<usize, Token<'a>, &'a str>> for EvaluationError<'a> {

--- a/jexl-eval/src/lib.rs
+++ b/jexl-eval/src/lib.rs
@@ -8,13 +8,15 @@
 //! JEXL is an expression language used by Mozilla, you can find more information here: https://github.com/mozilla/mozjexl
 //!
 //! # How to use
-//! The access point for this crate is the `eval` functions
+//! The access point for this crate is the `eval` functions of the Evaluator Struct
 //! You can use the `eval` function directly to evaluate standalone statements
 //!
 //! For example:
 //! ```rust
-//! use jexl_eval::eval;
-//! assert_eq!(eval("'Hello ' + 'World'").unwrap(), "Hello World");
+//! use jexl_eval::Evaluator;
+//! use serde_json::json as value;
+//! let evaluator = Evaluator::new();
+//! assert_eq!(evaluator.eval("'Hello ' + 'World'").unwrap(), value!("Hello World"));
 //! ```
 //!
 //! You can also run the statements against a context using the `eval_in_context` function
@@ -23,10 +25,11 @@
 //!
 //! For example:
 //! ```rust
-//! use jexl_eval::eval_in_context;
+//! use jexl_eval::Evaluator;
 //! use serde_json::json as value;
 //! let context = value!({"a": {"b": 2.0}});
-//! assert_eq!(eval_in_context("a.b", context).unwrap(), value!(2.0));
+//! let evaluator = Evaluator::new();
+//! assert_eq!(evaluator.eval_in_context("a.b", context).unwrap(), value!(2.0));
 //! ```
 //!
 
@@ -38,6 +41,7 @@ use serde_json::{json as value, Value};
 
 pub mod error;
 use error::*;
+use std::collections::HashMap;
 
 const EPSILON: f64 = 0.000001f64;
 
@@ -67,103 +71,162 @@ impl Truthy for Value {
 
 type Context = Value;
 
-pub fn eval(input: &str) -> Result<'_, Value> {
-    let context = value!({});
-    eval_in_context(input, &context)
+/// TransformFn represents an arbitrary transform function
+/// Transform functions take a `serde_json::Value`to represent their arguments
+/// and return a `serde_json::Value`.
+/// the transform function itself is responsible for checking if the format of
+/// the arguments is correct
+// TODO: Make this return a result and deal with the lifetime of the error..
+type TransformFn = Box<dyn Fn(Value) -> Value>;
+
+#[derive(Default)]
+pub struct Evaluator {
+    transforms: HashMap<String, TransformFn>,
 }
 
-pub fn eval_in_context<T: serde::Serialize>(input: &str, context: T) -> Result<'_, Value> {
-    let tree = Parser::parse(input)?;
-    let context = serde_json::to_value(context)?;
-    if !context.is_object() {
-        return Err(EvaluationError::InvalidContext);
+impl Evaluator {
+    pub fn new() -> Self {
+        Self::default()
     }
-    eval_ast(tree, &context)
-}
 
-fn eval_ast<'a>(ast: Expression, context: &Context) -> Result<'a, Value> {
-    match ast {
-        Expression::Number(n) => Ok(value!(n)),
-        Expression::Boolean(b) => Ok(value!(b)),
-        Expression::String(s) => Ok(value!(s)),
-        Expression::Array(xs) => xs.into_iter().map(|x| eval_ast(*x, context)).collect(),
+    /// Adds a custom transform function
+    /// This is meant as a way to allow consumers to add their own custom functionality
+    /// to the expression language.
+    /// Note that the name added here has to match with
+    /// the name that the transform will have when it's a part of the expression statement
+    ///
+    /// # Arguments:
+    /// - `name`: The name of the transfrom
+    /// - `transform`: The actual function. A Box<dyn Fn(serde_json::Value) -> Value>
+    ///
+    /// # Example:
+    ///
+    /// ```rust
+    /// use jexl_eval::Evaluator;
+    /// use serde_json::{json as value, Value};
+    ///
+    /// let mut evaluator = Evaluator::new();
+    /// evaluator.add_transform("lower", Box::new(|v: Value| {
+    ///    let s = v.as_str().expect("Should be a string!");
+    ///    value!(s.to_lowercase())
+    ///  }));
+    ///
+    /// assert_eq!(evaluator.eval("'JOHN DOe'|lower").unwrap(), value!("john doe"))
+    /// ```
+    pub fn add_transform(&mut self, name: &str, transform: TransformFn) {
+        self.transforms.insert(name.to_string(), transform);
+    }
 
-        Expression::Object(items) => {
-            let mut map = serde_json::Map::with_capacity(items.len());
-            for (key, expr) in items.into_iter() {
-                if map.contains_key(&key) {
-                    return Err(EvaluationError::DuplicateObjectKey(key));
-                }
-                let value = eval_ast(*expr, context)?;
-                map.insert(key, value);
-            }
-            Ok(Value::Object(map))
+    pub fn eval<'a>(&self, input: &'a str) -> Result<'a, Value> {
+        let context = value!({});
+        self.eval_in_context(input, &context)
+    }
+
+    pub fn eval_in_context<'a, T: serde::Serialize>(
+        &self,
+        input: &'a str,
+        context: T,
+    ) -> Result<'a, Value> {
+        let tree = Parser::parse(input)?;
+        let context = serde_json::to_value(context)?;
+        if !context.is_object() {
+            return Err(EvaluationError::InvalidContext);
         }
+        self.eval_ast(tree, &context)
+    }
 
-        Expression::IdentifierSequence(exprs) => {
-            assert!(!exprs.is_empty());
-            let mut rv: Option<&Value> = Some(context);
-            for expr in exprs.into_iter() {
-                let key = eval_ast(*expr, context)?;
-                if let Some(value) = rv {
-                    rv = match key {
-                        Value::String(s) => value.get(&s),
-                        Value::Number(f) => value.get(f.as_f64().unwrap().floor() as usize),
-                        _ => return Err(EvaluationError::InvalidIndexType),
-                    };
-                } else {
-                    break;
+    fn eval_ast<'a>(&self, ast: Expression, context: &Context) -> Result<'a, Value> {
+        match ast {
+            Expression::Number(n) => Ok(value!(n)),
+            Expression::Boolean(b) => Ok(value!(b)),
+            Expression::String(s) => Ok(value!(s)),
+            Expression::Array(xs) => xs.into_iter().map(|x| self.eval_ast(*x, context)).collect(),
+
+            Expression::Object(items) => {
+                let mut map = serde_json::Map::with_capacity(items.len());
+                for (key, expr) in items.into_iter() {
+                    if map.contains_key(&key) {
+                        return Err(EvaluationError::DuplicateObjectKey(key));
+                    }
+                    let value = self.eval_ast(*expr, context)?;
+                    map.insert(key, value);
                 }
+                Ok(Value::Object(map))
             }
 
-            Ok(rv.unwrap_or(&value!(null)).clone())
-        }
-
-        Expression::BinaryOperation {
-            left,
-            right,
-            operation,
-        } => {
-            let left = eval_ast(*left, context)?;
-            let right = eval_ast(*right, context)?;
-            match (operation, left, right) {
-                (OpCode::And, a, b) => Ok(if a.is_truthy() { b } else { a }),
-                (OpCode::Or, a, b) => Ok(if a.is_truthy() { a } else { b }),
-
-                (op, Value::Number(a), Value::Number(b)) => {
-                    let left = a.as_f64().unwrap();
-                    let right = b.as_f64().unwrap();
-                    Ok(match op {
-                        OpCode::Add => value!(left + right),
-                        OpCode::Subtract => value!(left - right),
-                        OpCode::Multiply => value!(left * right),
-                        OpCode::Divide => value!(left / right),
-                        OpCode::FloorDivide => value!((left / right).floor()),
-                        OpCode::Modulus => value!(left % right),
-                        OpCode::Exponent => value!(left.powf(right)),
-                        OpCode::Less => value!(left < right),
-                        OpCode::Greater => value!(left > right),
-                        OpCode::LessEqual => value!(left <= right),
-                        OpCode::GreaterEqual => value!(left >= right),
-                        OpCode::Equal => value!((left - right).abs() < EPSILON),
-                        OpCode::NotEqual => value!((left - right).abs() > EPSILON),
-                        OpCode::In => value!(false),
-                        OpCode::And | OpCode::Or => {
-                            unreachable!("Covered by previous case in parent match")
-                        }
-                    })
+            Expression::IdentifierSequence(exprs) => {
+                assert!(!exprs.is_empty());
+                let mut rv: Option<&Value> = Some(context);
+                for expr in exprs.into_iter() {
+                    let key = self.eval_ast(*expr, context)?;
+                    if let Some(value) = rv {
+                        rv = match key {
+                            Value::String(s) => value.get(&s),
+                            Value::Number(f) => value.get(f.as_f64().unwrap().floor() as usize),
+                            _ => return Err(EvaluationError::InvalidIndexType),
+                        };
+                    } else {
+                        break;
+                    }
                 }
 
-                (OpCode::Add, Value::String(a), Value::String(b)) => {
-                    Ok(value!(format!("{}{}", a, b)))
+                Ok(rv.unwrap_or(&value!(null)).clone())
+            }
+
+            Expression::BinaryOperation {
+                left,
+                right,
+                operation,
+            } => {
+                let left = self.eval_ast(*left, context)?;
+                let right = self.eval_ast(*right, context)?;
+                match (operation, left, right) {
+                    (OpCode::And, a, b) => Ok(if a.is_truthy() { b } else { a }),
+                    (OpCode::Or, a, b) => Ok(if a.is_truthy() { a } else { b }),
+
+                    (op, Value::Number(a), Value::Number(b)) => {
+                        let left = a.as_f64().unwrap();
+                        let right = b.as_f64().unwrap();
+                        Ok(match op {
+                            OpCode::Add => value!(left + right),
+                            OpCode::Subtract => value!(left - right),
+                            OpCode::Multiply => value!(left * right),
+                            OpCode::Divide => value!(left / right),
+                            OpCode::FloorDivide => value!((left / right).floor()),
+                            OpCode::Modulus => value!(left % right),
+                            OpCode::Exponent => value!(left.powf(right)),
+                            OpCode::Less => value!(left < right),
+                            OpCode::Greater => value!(left > right),
+                            OpCode::LessEqual => value!(left <= right),
+                            OpCode::GreaterEqual => value!(left >= right),
+                            OpCode::Equal => value!((left - right).abs() < EPSILON),
+                            OpCode::NotEqual => value!((left - right).abs() > EPSILON),
+                            OpCode::In => value!(false),
+                            OpCode::And | OpCode::Or => {
+                                unreachable!("Covered by previous case in parent match")
+                            }
+                        })
+                    }
+
+                    (OpCode::Add, Value::String(a), Value::String(b)) => {
+                        Ok(value!(format!("{}{}", a, b)))
+                    }
+                    (OpCode::In, Value::String(a), Value::String(b)) => Ok(value!(b.contains(&a))),
+                    (OpCode::Equal, Value::String(a), Value::String(b)) => Ok(value!(a == b)),
+                    (operation, left, right) => Err(EvaluationError::InvalidBinaryOp {
+                        operation,
+                        left,
+                        right,
+                    }),
                 }
-                (OpCode::In, Value::String(a), Value::String(b)) => Ok(value!(b.contains(&a))),
-                (OpCode::Equal, Value::String(a), Value::String(b)) => Ok(value!(a == b)),
-                (operation, left, right) => Err(EvaluationError::InvalidBinaryOp {
-                    operation,
-                    left,
-                    right,
-                }),
+            }
+            Expression::Transform { name, args } => {
+                let args = self.eval_ast(*args, context)?;
+                let f = self
+                    .transforms
+                    .get(&name)
+                    .ok_or(EvaluationError::UnknownTransform(name))?;
+                Ok(f(args))
             }
         }
     }
@@ -176,48 +239,53 @@ mod tests {
 
     #[test]
     fn test_literal() {
-        assert_eq!(eval("1").unwrap(), value!(1.0));
+        assert_eq!(Evaluator::new().eval("1").unwrap(), value!(1.0));
     }
 
     #[test]
     fn test_binary_expression_addition() {
-        assert_eq!(eval("1 + 2").unwrap(), value!(3.0));
+        assert_eq!(Evaluator::new().eval("1 + 2").unwrap(), value!(3.0));
     }
 
     #[test]
     fn test_binary_expression_multiplication() {
-        assert_eq!(eval("2 * 3").unwrap(), value!(6.0));
+        assert_eq!(Evaluator::new().eval("2 * 3").unwrap(), value!(6.0));
     }
 
     #[test]
     fn test_precedence() {
-        assert_eq!(eval("2 + 3 * 4").unwrap(), value!(14.0));
+        assert_eq!(Evaluator::new().eval("2 + 3 * 4").unwrap(), value!(14.0));
     }
 
     #[test]
     fn test_parenthesis() {
-        assert_eq!(eval("(2 + 3) * 4").unwrap(), value!(20.0));
+        assert_eq!(Evaluator::new().eval("(2 + 3) * 4").unwrap(), value!(20.0));
     }
 
     #[test]
     fn test_string_concat() {
-        assert_eq!(eval("'Hello ' + 'World'").unwrap(), value!("Hello World"));
+        assert_eq!(
+            Evaluator::new().eval("'Hello ' + 'World'").unwrap(),
+            value!("Hello World")
+        );
     }
 
     #[test]
     fn test_true_comparison() {
-        assert_eq!(eval("2 > 1").unwrap(), value!(true));
+        assert_eq!(Evaluator::new().eval("2 > 1").unwrap(), value!(true));
     }
 
     #[test]
     fn test_false_comparison() {
-        assert_eq!(eval("2 <= 1").unwrap(), value!(false));
+        assert_eq!(Evaluator::new().eval("2 <= 1").unwrap(), value!(false));
     }
 
     #[test]
     fn test_boolean_logic() {
         assert_eq!(
-            eval("'foo' && 6 >= 6 && 0 + 1 && true").unwrap(),
+            Evaluator::new()
+                .eval("'foo' && 6 >= 6 && 0 + 1 && true")
+                .unwrap(),
             value!(true)
         );
     }
@@ -225,13 +293,19 @@ mod tests {
     #[test]
     fn test_identifier() {
         let context = value!({"a": 1.0});
-        assert_eq!(eval_in_context("a", context).unwrap(), value!(1.0));
+        assert_eq!(
+            Evaluator::new().eval_in_context("a", context).unwrap(),
+            value!(1.0)
+        );
     }
 
     #[test]
     fn test_identifier_chain() {
         let context = value!({"a": {"b": 2.0}});
-        assert_eq!(eval_in_context("a.b", context).unwrap(), value!(2.0));
+        assert_eq!(
+            Evaluator::new().eval_in_context("a.b", context).unwrap(),
+            value!(2.0)
+        );
     }
 
     #[test]
@@ -247,7 +321,9 @@ mod tests {
             }
         });
         assert_eq!(
-            eval_in_context("foo.bar[.tek == 'baz']", &context).unwrap(),
+            Evaluator::new()
+                .eval_in_context("foo.bar[.tek == 'baz']", &context)
+                .unwrap(),
             value!([{"tek": "baz"}])
         );
     }
@@ -264,7 +340,9 @@ mod tests {
             }
         });
         assert_eq!(
-            eval_in_context("foo.bar[1].tek", context).unwrap(),
+            Evaluator::new()
+                .eval_in_context("foo.bar[1].tek", context)
+                .unwrap(),
             value!("baz")
         );
     }
@@ -274,36 +352,27 @@ mod tests {
     fn test_object_expression_properties() {
         let context = value!({"foo": {"baz": {"bar": "tek"}}});
         assert_eq!(
-            eval_in_context("foo['ba' + 'z']", &context).unwrap(),
+            Evaluator::new()
+                .eval_in_context("foo['ba' + 'z']", &context)
+                .unwrap(),
             value!("tek")
         );
     }
 
     #[test]
-    #[should_panic]
-    fn test_missing_transform_exception() {
-        let err = eval("'hello'|world").unwrap_err();
-        if let EvaluationError::UnknownTransform(transform) = err {
-            assert_eq!(transform, "world")
-        } else {
-            panic!("Should have thrown an unknown transform error")
-        }
-    }
-
-    #[test]
     fn test_divfloor() {
-        assert_eq!(eval("7 // 2").unwrap(), value!(3.0));
+        assert_eq!(Evaluator::new().eval("7 // 2").unwrap(), value!(3.0));
     }
 
     #[test]
     fn test_empty_object_literal() {
-        assert_eq!(eval("{}").unwrap(), value!({}));
+        assert_eq!(Evaluator::new().eval("{}").unwrap(), value!({}));
     }
 
     #[test]
     fn test_object_literal_strings() {
         assert_eq!(
-            eval("{'foo': {'bar': 'tek'}}").unwrap(),
+            Evaluator::new().eval("{'foo': {'bar': 'tek'}}").unwrap(),
             value!({"foo": {"bar": "tek"}})
         );
     }
@@ -312,7 +381,7 @@ mod tests {
     #[should_panic]
     fn test_object_literal_identifiers() {
         assert_eq!(
-            eval("{foo: {bar: 'tek'}}").unwrap(),
+            Evaluator::new().eval("{foo: {bar: 'tek'}}").unwrap(),
             value!({"foo": {"bar": "tek"}})
         );
     }
@@ -326,8 +395,8 @@ mod tests {
             default_binary_operators,
             default_unary_operators
         )
-        evaluator = Evaluator(config)
-        result = evaluate(tree('foo|half + 3'), {'foo': 10})
+        Evaluator::new().evaluator = Evaluator::new().evaluator(config)
+        result = Evaluator::new().evaluate(tree('foo|half + 3'), {'foo': 10})
         assert result == 8
 
     def test_transforms_multiple_arguments():
@@ -338,8 +407,8 @@ mod tests {
                 'concat': lambda val, a1, a2, a3: val + ': ' + a1 + a2 + a3,
             }
         )
-        evaluator = Evaluator(config)
-        result = evaluate(tree('"foo"|concat("baz", "bar", "tek")'))
+        Evaluator::new().evaluator = Evaluator::new().evaluator(config)
+        result = Evaluator::new().evaluate(tree('"foo"|concat("baz", "bar", "tek")'))
         assert result == 'foo: bazbartek'
 
     */
@@ -347,35 +416,51 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_object_literal_properties() {
-        assert_eq!(eval("{foo: 'bar'}.foo").unwrap(), value!("bar"));
+        assert_eq!(
+            Evaluator::new().eval("{foo: 'bar'}.foo").unwrap(),
+            value!("bar")
+        );
     }
 
     #[test]
     fn test_array_literal() {
-        assert_eq!(eval("['foo', 1+2]").unwrap(), value!(["foo", 3.0]));
+        assert_eq!(
+            Evaluator::new().eval("['foo', 1+2]").unwrap(),
+            value!(["foo", 3.0])
+        );
     }
 
     #[test]
     #[should_panic]
     fn test_array_literal_indexing() {
-        assert_eq!(eval("[1, 2, 3][1]").unwrap(), value!(2.0));
+        assert_eq!(Evaluator::new().eval("[1, 2, 3][1]").unwrap(), value!(2.0));
     }
 
     #[test]
     fn test_in_operator_string() {
-        assert_eq!(eval("'bar' in 'foobartek'").unwrap(), value!(true));
-        assert_eq!(eval("'baz' in 'foobartek'").unwrap(), value!(false));
+        assert_eq!(
+            Evaluator::new().eval("'bar' in 'foobartek'").unwrap(),
+            value!(true)
+        );
+        assert_eq!(
+            Evaluator::new().eval("'baz' in 'foobartek'").unwrap(),
+            value!(false)
+        );
     }
 
     #[test]
     #[should_panic]
     fn test_in_operator_array() {
         assert_eq!(
-            eval("'bar' in ['foo', 'bar', 'tek']").unwrap(),
+            Evaluator::new()
+                .eval("'bar' in ['foo', 'bar', 'tek']")
+                .unwrap(),
             value!(true)
         );
         assert_eq!(
-            eval("'baz' in ['foo', 'bar', 'tek']").unwrap(),
+            Evaluator::new()
+                .eval("'baz' in ['foo', 'bar', 'tek']")
+                .unwrap(),
             value!(false)
         );
     }
@@ -383,29 +468,63 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_conditional_expression() {
-        assert_eq!(eval("'foo' ? 1 : 2").unwrap(), value!(1));
-        assert_eq!(eval("'' ? 1 : 2").unwrap(), value!(2));
+        assert_eq!(Evaluator::new().eval("'foo' ? 1 : 2").unwrap(), value!(1));
+        assert_eq!(Evaluator::new().eval("'' ? 1 : 2").unwrap(), value!(2));
     }
 
     #[test]
     fn test_arbitrary_whitespace() {
-        assert_eq!(eval("(\t2\n+\n3) *\n4\n\r\n").unwrap(), value!(20.0));
+        assert_eq!(
+            Evaluator::new().eval("(\t2\n+\n3) *\n4\n\r\n").unwrap(),
+            value!(20.0)
+        );
     }
 
     #[test]
     fn test_non_integer() {
-        assert_eq!(eval("1.5 * 3.0").unwrap(), value!(4.5));
+        assert_eq!(Evaluator::new().eval("1.5 * 3.0").unwrap(), value!(4.5));
     }
 
     #[test]
     fn test_string_literal() {
-        assert_eq!(eval("'hello world'").unwrap(), value!("hello world"));
-        assert_eq!(eval("\"hello world\"").unwrap(), value!("hello world"));
+        assert_eq!(
+            Evaluator::new().eval("'hello world'").unwrap(),
+            value!("hello world")
+        );
+        assert_eq!(
+            Evaluator::new().eval("\"hello world\"").unwrap(),
+            value!("hello world")
+        );
     }
 
     #[test]
     fn test_string_escapes() {
-        assert_eq!(eval("'a\\'b'").unwrap(), value!("a'b"));
-        assert_eq!(eval("\"a\\\"b\"").unwrap(), value!("a\"b"));
+        assert_eq!(Evaluator::new().eval("'a\\'b'").unwrap(), value!("a'b"));
+        assert_eq!(Evaluator::new().eval("\"a\\\"b\"").unwrap(), value!("a\"b"));
+    }
+
+    #[test]
+    // Test a very simple transform that applies to_lowercase to a string
+    fn test_simple_transform() {
+        let mut evaluator = Evaluator::new();
+        evaluator.add_transform(
+            "lower",
+            Box::new(|v: Value| {
+                let s = v.as_str().expect("Should be a string!");
+                value!(s.to_lowercase())
+            }),
+        );
+        assert_eq!(evaluator.eval("'T_T'|lower").unwrap(), value!("t_t"));
+    }
+
+    #[test]
+    // Test returning an UnknownTransform error if a transform is unknown
+    fn test_missing_transform() {
+        let err = Evaluator::new().eval("'hello'|world").unwrap_err();
+        if let EvaluationError::UnknownTransform(transform) = err {
+            assert_eq!(transform, "world")
+        } else {
+            panic!("Should have thrown an unknown transform error")
+        }
     }
 }

--- a/jexl-parser/src/ast.rs
+++ b/jexl-parser/src/ast.rs
@@ -17,7 +17,8 @@ pub enum Expression {
     },
     Transform {
         name: String,
-        args: Box<Expression>,
+        subject: Box<Expression>,
+        args: Option<Vec<Box<Expression>>>,
     },
 }
 

--- a/jexl-parser/src/ast.rs
+++ b/jexl-parser/src/ast.rs
@@ -15,6 +15,10 @@ pub enum Expression {
         left: Box<Expression>,
         right: Box<Expression>,
     },
+    Transform {
+        name: String,
+        args: Box<Expression>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/jexl-parser/src/lib.rs
+++ b/jexl-parser/src/lib.rs
@@ -47,14 +47,49 @@ mod tests {
     }
 
     #[test]
-    fn transform_simple() {
-        let exp = "\"T_T\"|lower";
+    fn transform_simple_no_args() {
+        let exp = "'T_T'|lower";
         let parsed = Parser::parse(exp).unwrap();
         assert_eq!(
             parsed,
             Expression::Transform {
                 name: "lower".to_string(),
-                args: Box::new(Expression::String("T_T".to_string()))
+                subject: Box::new(Expression::String("T_T".to_string())),
+                args: None
+            }
+        );
+    }
+
+    #[test]
+    fn transform_multiple_args() {
+        let exp = "'John Doe'|split(' ')";
+        let parsed = Parser::parse(exp).unwrap();
+        assert_eq!(
+            parsed,
+            Expression::Transform {
+                name: "split".to_string(),
+                subject: Box::new(Expression::String("John Doe".to_string())),
+                args: Some(vec![Box::new(Expression::String(" ".to_string()))])
+            }
+        );
+    }
+
+    #[test]
+    fn trasform_way_too_many_args() {
+        let exp = "123456|math(12, 35, 100, 31, 90)";
+        let parsed = Parser::parse(exp).unwrap();
+        assert_eq!(
+            parsed,
+            Expression::Transform {
+                name: "math".to_string(),
+                subject: Box::new(Expression::Number(123_456f64)),
+                args: Some(vec![
+                    Box::new(Expression::Number(12f64)),
+                    Box::new(Expression::Number(35f64)),
+                    Box::new(Expression::Number(100f64)),
+                    Box::new(Expression::Number(31f64)),
+                    Box::new(Expression::Number(90f64)),
+                ])
             }
         );
     }

--- a/jexl-parser/src/lib.rs
+++ b/jexl-parser/src/lib.rs
@@ -45,4 +45,17 @@ mod tests {
     fn binary_expression_whitespace() {
         assert_eq!(Parser::parse("1  +     2 "), Parser::parse("1+2"),);
     }
+
+    #[test]
+    fn transform_simple() {
+        let exp = "\"T_T\"|lower";
+        let parsed = Parser::parse(exp).unwrap();
+        assert_eq!(
+            parsed,
+            Expression::Transform {
+                name: "lower".to_string(),
+                args: Box::new(Expression::String("T_T".to_string()))
+            }
+        );
+    }
 }

--- a/jexl-parser/src/parser.lalrpop
+++ b/jexl-parser/src/parser.lalrpop
@@ -32,6 +32,11 @@ Expr40: Box<Expression> = {
 };
 
 Expr50: Box<Expression> = {
+    <args: Expr50> "|" <name: Identifier> => Box::new(Expression::Transform{name, args}),
+    Expr60
+}
+
+Expr60: Box<Expression> = {
     Number => Box::new(Expression::Number(<>)),
     Boolean => Box::new(Expression::Boolean(<>)),
     String => Box::new(Expression::String(<>)),

--- a/jexl-parser/src/parser.lalrpop
+++ b/jexl-parser/src/parser.lalrpop
@@ -32,7 +32,7 @@ Expr40: Box<Expression> = {
 };
 
 Expr50: Box<Expression> = {
-    <args: Expr50> "|" <name: Identifier> => Box::new(Expression::Transform{name, args}),
+    <subject: Expr50> "|" <name: Identifier> <args: Args?> => Box::new(Expression::Transform{name, subject, args}),
     Expr60
 }
 
@@ -44,6 +44,10 @@ Expr60: Box<Expression> = {
     Object => Box::new(Expression::Object(<>)),
     IdentifierSequence => Box::new(Expression::IdentifierSequence(<>)),
     "(" <Expression> ")",
+};
+
+Args: Vec<Box<Expression>> = {
+    "(" <Comma<Expression>> ")"
 };
 
 Op10: OpCode = {


### PR DESCRIPTION
fixes #2 

#### What's in this?
- Adds support for parsing transforms.
- Adding arbitrary transforms into the `Evaluator`
- Simple test
- For the time being the transforms take a slice of `serde_json::Value` and return a `Result<serde_json::Value, anyhow::Error>`. There might be a better format here (generics may help?) but this seems intuitive given that we do a lot of work with `serde_json::Value` in this crate.

#### What else do we need?
- [x] A way to model multiple arguments, namely arguments that get passed directly, for example, the `' '` in:
```
"'Tarik Eshaq'|split(' ')"
```
- [x] More tests, we already have a few commented out.
- [x] ~~Revisit the syntax tree and make sure the transforms are okay where they are.~~ we can revisit this if we face any issue with more complex syntax not being parsed, it's easy to move it around
- [x] Careful error handling for errors that happen inside a transform (Allow arbitrary error types, since consumers will be writing those transforms
