### PR TITLE
Fixes array literal indexing

### DIFF
--- a/jexl-eval/src/lib.rs
+++ b/jexl-eval/src/lib.rs
@@ -164,23 +164,30 @@ impl<'a> Evaluator<'a> {
                 Ok(Value::Object(map))
             }
 
-            Expression::IdentifierSequence(exprs) => {
-                assert!(!exprs.is_empty());
-                let mut rv: Option<&Value> = Some(context);
-                for expr in exprs.into_iter() {
-                    let key = self.eval_ast(*expr, context)?;
-                    if let Some(value) = rv {
-                        rv = match key {
-                            Value::String(s) => value.get(&s),
-                            Value::Number(f) => value.get(f.as_f64().unwrap().floor() as usize),
-                            _ => return Err(EvaluationError::InvalidIndexType),
-                        };
-                    } else {
-                        break;
-                    }
-                }
+            Expression::Identifier(inner) => {
+                // TODO: Make this error out if the identifier does not exist in the
+                // context
+                Ok(context.get(&inner).unwrap_or(&value!(null)).clone())
+            }
 
-                Ok(rv.unwrap_or(&value!(null)).clone())
+            Expression::DotOperation { subject, ident } => {
+                let subject = self.eval_ast(*subject, context)?;
+                Ok(subject.get(&ident).unwrap_or(&value!(null)).clone())
+            }
+
+            Expression::IndexOperation { subject, index } => {
+                let subject = self.eval_ast(*subject, context)?;
+                let index = self.eval_ast(*index, context)?;
+                match index {
+                    Value::String(inner) => {
+                        Ok(subject.get(&inner).unwrap_or(&value!(null)).clone())
+                    }
+                    Value::Number(inner) => Ok(subject
+                        .get(inner.as_f64().unwrap().floor() as usize)
+                        .unwrap_or(&value!(null))
+                        .clone()),
+                    _ => Err(EvaluationError::InvalidIndexType),
+                }
             }
 
             Expression::BinaryOperation {
@@ -425,7 +432,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_array_literal_indexing() {
         assert_eq!(Evaluator::new().eval("[1, 2, 3][1]").unwrap(), value!(2.0));
     }

--- a/jexl-parser/src/ast.rs
+++ b/jexl-parser/src/ast.rs
@@ -9,7 +9,6 @@ pub enum Expression {
     Boolean(bool),
     Array(Vec<Box<Expression>>),
     Object(Vec<(String, Box<Expression>)>),
-    IdentifierSequence(Vec<Box<Expression>>),
     BinaryOperation {
         operation: OpCode,
         left: Box<Expression>,
@@ -20,6 +19,16 @@ pub enum Expression {
         subject: Box<Expression>,
         args: Option<Vec<Box<Expression>>>,
     },
+    DotOperation {
+        subject: Box<Expression>,
+        ident: String,
+    },
+    IndexOperation {
+        subject: Box<Expression>,
+        index: Box<Expression>,
+    },
+
+    Identifier(String),
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/jexl-parser/src/lib.rs
+++ b/jexl-parser/src/lib.rs
@@ -93,4 +93,63 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_index_op_ident() {
+        let exp = "foo[0]";
+        let parsed = Parser::parse(exp).unwrap();
+        assert_eq!(
+            parsed,
+            Expression::IndexOperation {
+                subject: Box::new(Expression::Identifier("foo".to_string())),
+                index: Box::new(Expression::Number(0f64))
+            }
+        );
+    }
+
+    #[test]
+    fn test_index_op_array_literal() {
+        let exp = "[1, 2, 3][0]";
+        let parsed = Parser::parse(exp).unwrap();
+        assert_eq!(
+            parsed,
+            Expression::IndexOperation {
+                subject: Box::new(Expression::Array(vec![
+                    Box::new(Expression::Number(1f64)),
+                    Box::new(Expression::Number(2f64)),
+                    Box::new(Expression::Number(3f64)),
+                ])),
+                index: Box::new(Expression::Number(0f64))
+            }
+        );
+    }
+
+    #[test]
+    fn test_dot_op_ident() {
+        let exp = "foo.bar";
+        let parsed = Parser::parse(exp).unwrap();
+        assert_eq!(
+            parsed,
+            Expression::DotOperation {
+                subject: Box::new(Expression::Identifier("foo".to_string())),
+                ident: "bar".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_dot_op_object_literal() {
+        let exp = "{'foo': 1}.foo";
+        let parsed = Parser::parse(exp).unwrap();
+        assert_eq!(
+            parsed,
+            Expression::DotOperation {
+                subject: Box::new(Expression::Object(vec![(
+                    "foo".to_string(),
+                    Box::new(Expression::Number(1f64))
+                )])),
+                ident: "foo".to_string()
+            }
+        );
+    }
 }

--- a/jexl-parser/src/parser.lalrpop
+++ b/jexl-parser/src/parser.lalrpop
@@ -34,15 +34,43 @@ Expr40: Box<Expression> = {
 Expr50: Box<Expression> = {
     <subject: Expr50> "|" <name: Identifier> <args: Args?> => Box::new(Expression::Transform{name, subject, args}),
     Expr60
-}
+};
 
+/// Expression for dereferencing.
+/// Used for dereferencing object literals, array literals, and the context
+/// There are two types of operations here:
+/// - Either a `dot` operation, taking an expression on the left hand side, and an identifier on the right hand side (a string without the quotations)
+/// - Or an `index` operation, taking an expression on the left hand side, and another expression inside square ("[]") brackets.
+///
+/// # Examples:
+/// 
+/// Assume our context is the following
+/// ```
+///{
+///  "foo":
+///  {
+///     "bar": [{"baz": 1}, {"bobo": [13, 12]}]
+//   }
+// }
+/// ```
+///
+/// `foo.bar == [{"baz": 1}, {"bobo": [13, 12]]`
+/// `foo.bar[0] == {"baz": 1}`
+/// `foo.bar[1].bobo[0] == 13`
+/// `[1, 2, 3][1] == 2`
 Expr60: Box<Expression> = {
+    <subject: Expr60> <index: Index> => Box::new(Expression::IndexOperation{subject, index}),
+    <subject: Expr60> "." <ident: Identifier>  => Box::new(Expression::DotOperation{subject, ident}),
+    Expr70
+};
+
+Expr70: Box<Expression> = {
     Number => Box::new(Expression::Number(<>)),
     Boolean => Box::new(Expression::Boolean(<>)),
     String => Box::new(Expression::String(<>)),
     Array => Box::new(Expression::Array(<>)),
     Object => Box::new(Expression::Object(<>)),
-    IdentifierSequence => Box::new(Expression::IdentifierSequence(<>)),
+    Identifier => Box::new(Expression::Identifier(<>)),
     "(" <Expression> ")",
 };
 
@@ -92,24 +120,15 @@ String: String = {
     <s: r#"'([^'\\]*(\\')?)*'"#> => s[1..s.len() - 1].to_string().replace("\\'", "'"),
 };
 
-IdentifierSequence: Vec<Box<Expression>> = {
-    <head: Identifier> <tail: (IdentifierSequenceTailPart*)> => {
-        let mut rv = Vec::with_capacity(tail.len() + 1);
-        let mut tail = tail;
-        rv.push(Box::new(Expression::String(head)));
-        rv.append(&mut tail);
-        rv
-    }
-};
 
 Identifier: String = {
     r#"[a-zA-Z_][a-zA-Z0-9_]*"# => <>.to_string()
 }
 
-IdentifierSequenceTailPart: Box<Expression> = {
-    "." <Identifier> => Box::new(Expression::String(<>)),
-    "[" <Expression> "]",
-};
+Index: Box<Expression> = {
+    "[" <Expression> "]"
+}
+
 
 Boolean: bool = {
     "true" => true,


### PR DESCRIPTION
connects to #6 

Fixes array literal indexing. 

#### What's in this?
- Splits the `IdentifierSequence` to its individual operations, the `DotOperation` and `IndexOperation`, plus a `Identifier` expression to represent standalone identifiers (referencing the context)
- Adds tests for parsing the added operations, and removes the `should_panic` on the array literal indexing test
- Adds some documentation on the `.lalrpop` file

#### Okay, wat?
So we had an `IdentifierSequence` expression type, which was meant to represent expressions like this:
`foo.bar[0].bobo`.

It works nicely, however, it assumes that the `head` (in this case `foo`) of the sequence (a sequence of operations) is always going to be an identifier. This is not the case when we have a sequence starting with an array or object literal, i.e:
`[1, 2, 3][0]`

In reality, the `head` can be any expression. So, in here we split the operations so that they can have an arbitrary expression as a `head`, and recursively evaluate that before applying the operation. And since we _often_ will have identifiers as the `head`, we needed an additional `Identifier` expression type.