### PR TITLE
Adds filtering collections

### DIFF
--- a/jexl-eval/src/error.rs
+++ b/jexl-eval/src/error.rs
@@ -29,6 +29,8 @@ pub enum EvaluationError<'a> {
     JSONError(#[from] serde_json::Error),
     #[error("Custom error: {0}")]
     CustomError(#[from] anyhow::Error),
+    #[error("Invalid filter")]
+    InvalidFilter,
 }
 
 impl<'a> From<ParseError<usize, Token<'a>, &'a str>> for EvaluationError<'a> {

--- a/jexl-parser/src/ast.rs
+++ b/jexl-parser/src/ast.rs
@@ -35,6 +35,12 @@ pub enum Expression {
         truthy: Box<Expression>,
         falsy: Box<Expression>,
     },
+
+    Filter {
+        ident: String,
+        op: OpCode,
+        right: Box<Expression>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]

--- a/jexl-parser/src/parser.lalrpop
+++ b/jexl-parser/src/parser.lalrpop
@@ -132,7 +132,8 @@ Identifier: String = {
 }
 
 Index: Box<Expression> = {
-    "[" <Expression> "]"
+    "[" "." <ident: Identifier> <op: Op20> <right: Expr80> "]" => Box::new(Expression::Filter {ident, op, right}),
+    "[" <Expression> "]",
 }
 
 


### PR DESCRIPTION
fixes #6 

This concludes the failing tests. There are two more things I'd like to do before assuming more or less complete behavior here, I'll open an issue for it, but I'll need to:
- Go ahead with writing complex tests that incorporate many of the jexl expressions together
- Do a 1-for-1 matching against https://github.com/mozilla/mozjexl/blob/master/test/evaluator/Evaluator.js for any missing test cases

Anywhoo

#### For this PR:

This PR adds support for filtering collections (which are arrays of objects), ref here: https://github.com/mozilla/mozjexl#collections