### PR TITLE
Fix README link to JEXL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jexl-rs [![CircleCI](https://circleci.com/gh/mozilla/jexl-rs/tree/main.svg?style=svg)](https://circleci.com/gh/mozilla/jexl-rs/tree/main)
 
-> [JEXL](https://commons.apache.org/proper/commons-jexl/) in Rust
+> [JEXL](https://www.npmjs.com/package/jexl) in Rust
 
 
 * jexl-eval: [![](https://meritbadge.herokuapp.com/jexl-eval)](https://crates.io/crates/jexl-eval) [![](https://docs.rs/jexl-eval/badge.svg?v=2)](https://docs.rs/jexl-eval)


### PR DESCRIPTION
The existing link is to the wrong JEXL. Apache's "Java Expression Language" is similar to, but not the same as the "JavaScript Expression Language" commonly in use at Mozilla.